### PR TITLE
cleaning the upload field after clear callback

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -200,6 +200,8 @@
             self.$preview.html('');
             self.$caption.html('');
             self.$container.removeClass('file-input-new').addClass('file-input-new');
+            
+            self.$element.attr('name', self.$name);
         },
         reset: function (e) {
             var self = this;


### PR DESCRIPTION
I do not understand why when cleaning the upload field, the name attribute of it disappears, then insert this line as a test and it worked perfectly
