### PR TITLE
Support <a> upload tag for disable/enable

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -428,14 +428,14 @@
             self.isDisabled = true;
             self.$element.attr('disabled', 'disabled');
             self.$container.find(".kv-fileinput-caption").addClass("file-caption-disabled");
-            self.$container.find(".btn-file, .fileinput-remove, .kv-fileinput-upload").attr("disabled", true);
+            self.$container.find(".btn-default, .btn-file, .fileinput-remove, .kv-fileinput-upload").attr("disabled", true);
         },
         enable: function (e) {
             var self = this;
             self.isDisabled = false;
             self.$element.removeAttr('disabled');
             self.$container.find(".kv-fileinput-caption").removeClass("file-caption-disabled");
-            self.$container.find(".btn-file, .fileinput-remove, .kv-fileinput-upload").removeAttr("disabled");
+            self.$container.find(".btn-default, .btn-file, .fileinput-remove, .kv-fileinput-upload").removeAttr("disabled");
         },
         hideFileIcon: function () {
             if (this.overwriteInitial) {


### PR DESCRIPTION
Disable "Upload" Button also when set as `<a>` tag instead of `<button>` (when using "uploadUrl" parameter). .btn-default which is used for the <a> tag, was not fetched thus it was still enabled when setting the whole component to disable
