### PR TITLE
Icon layout template undefined when using user template

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -1466,7 +1466,7 @@
         },
         setCaption: function(content) {
             var self = this, title = $('<div>' + content + '</div>').text(),
-                icon = self.layoutTemplates['icon'], 
+                icon = self.getLayoutTemplate('icon'), 
                 out = icon + title;
             if (self.$caption.length == 0) {
                 return;


### PR DESCRIPTION
When overriding at least one layout template, the plugin does not load the default layout templates into the `layoutTemplates` array. In that case, the icon layout is not retrieved correctly in `setCaption` function since it tries to access the `layoutTemplates` array instead of using the `getLayoutTemplate` function.

This issue can be reproduced with http://demos.krajee.com/widget-details/fileinput by setting the layoutTemplates option as follow:
```php
echo FileInput::widget([
    'pluginOptions' => [
        'layoutTemplates' => ['main1' => "{preview}\n<div class=\"kv-upload-progress hide\"></div>\n<div class=\"input-group {class}\">\n{caption}\n<div class=\"input-group-btn\">\n{remove}\n{cancel}\n{upload}\n{browse}\n</div>\n</div>"]
    ]
]);
```