### PR TITLE
Update fileinput.css

### DIFF
--- a/css/fileinput.css
+++ b/css/fileinput.css
@@ -48,7 +48,6 @@
 .file-caption .glyphicon {
     display: inline-block;
     min-width: 18px;
-    float: left;
     margin-top: 2px;
 }
 


### PR DESCRIPTION
修复在部分浏览器下，选择文件后，文件名过长导致换行而空白的问题（fixed a problem in CSS at some browser（like 360 browser））