### PR TITLE
Fixed license identifiers in bower.json and composer.json.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
         "jquery": ">= 1.9.0",
         "bootstrap": ">= 3.0.0"
     },
-    "license": "BSD-3",
+    "license": "BSD-3-Clause",
     "ignore": [
         "**/.*",
         "node_modules",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "An enhanced HTML 5 file input for Bootstrap 3.x with features for file preview for many file types, multiple selection, ajax uploads, and more.",
     "keywords": ["bootstrap", "jquery", "file", "input", "preview", "upload", "image", "multiple", "ajax", "delete", "progress"],
     "homepage": "https://github.com/kartik-v/bootstrap-fileinput",
-    "license": "BSD 3-Clause",
+    "license": "BSD-3-Clause",
     "authors": [
         {
             "name": "Kartik Visweswaran",


### PR DESCRIPTION
The license identifiers should conform to the SPDX Open Source License Registry entries. Right now some tools like Webjars will fail due to the mismatch of license tag.