### PR TITLE
Update Hungarian translations

### DIFF
--- a/js/fileinput_locale_hu.js
+++ b/js/fileinput_locale_hu.js
@@ -13,7 +13,7 @@
 
     $.fn.fileinputLocales['hu'] = {
         fileSingle: 'fájl',
-        filePlural: 'fájlok',
+        filePlural: 'fájl',
         browseLabel: 'Böngész &hellip;',
         removeLabel: 'Eltávolít',
         removeTitle: 'Kijelölt fájlok törlése',


### PR DESCRIPTION
Hi Kartik,

Plural for files is really "fájlok" in Hungarian, but the plural form does not make sense in the sentence it is currently used.
"2 files selected" in Hungarian is: "2 fájl kiválasztva".

Please update it.

Thanks!

Sly