### PR TITLE
`jquery` and `bootstrap`: `peerDependencies` ← `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "progress",
         "gallery"
     ],
-    "dependencies": {
+    "peerDependencies": {
         "jquery": ">= 1.9.0",
         "bootstrap": "~3"
     },


### PR DESCRIPTION
After this patch `jquery` and `bootstrap` are removed from the `dependencies` section of `package.json` and they're granted `peerDependencies` status instead of it.

Rationale:

* All of these three packages (`bootstrap-fileinput`, `bootstrap`, `jquery`) are quite likely to be defined as dependencies of their common parent application (which is, most likely, a web site; could also be an application built on [Electron](http://electron.atom.io/), [NW.js](http://nwjs.io/), [JXcore for Cordova](https://github.com/jxcore/jxcore-cordova/), etc.) and thus to become peers in that sense. Currently, if some version mismatch happens on that level (under that parent), `npm` would install another version of `bootstrap` or `jquery` under `bootstrap-fileinput` (and that would be the versions required by `bootstrap-fileinput` as its `dependencies`). However, because `bootstrap-fileinput` does not rely on Node.js `require()`, that npm's behaviour does not really help anything, and thus `npm` should rather **warn** on version mismatch, like it does with `peerDependencies`.

* Likewise, if a user prefers a download of Bootstrap's [customized version](http://getbootstrap.com/customize/) (or has some other reason to refrain from `npm install bootstrap`; for example, the user might think that a mere `<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">` and `<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js" type="text/javascript"></script>` is fine), then `npm` should not decide to install `bootstrap` dependency (which would be a non-customized version and won't be used anyway); a warning about a missing peerDependency would be enough.