### PR TITLE
Fixed unset method used for delete a previewCache index

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -204,10 +204,12 @@
             if (chk === 1) {
                 previewCache.data[id].content = [];
                 previewCache.data[id].config = [];
+                previewCache.data[id].tags = [];
                 return;
             }
             previewCache.data[id].content[index] = null;
             previewCache.data[id].config[index] = null;
+            previewCache.data[id].tags[index] = null;
         },
         out: function (id) {
             var html = '', data = previewCache.data[id], caption, len = previewCache.count(id, true);


### PR DESCRIPTION
We have to clean the tags array too.
There is a problem when we upload a file, delete the file, and upload another file, the tags are the same than the first file uploaded. Only occurs when we have custom layoutTemplates and previewThumbTags.