### PR TITLE
Update German Translations

### DIFF
--- a/js/fileinput_locale_de.js
+++ b/js/fileinput_locale_de.js
@@ -19,7 +19,7 @@
         cancelTitle: 'Hochladen abbrechen',
         uploadLabel: 'Hochladen',
         uploadTitle: 'Hochladen der ausgewählten Dateien',
-        msgNo: 'Nein',
+        msgNo: 'Keine',
         msgCancelled: 'Abgebrochen',
         msgZoomTitle: 'Details anzeigen',
         msgZoomModalHeading: 'ausführliche Vorschau',


### PR DESCRIPTION
This change fixes the displayed text when choosing a file which doesn't match the allowed file types (or other criteria).
The old incorrect text `"Nein Dateien ausgewählt"` now displays as `"Keine Dateien ausgewählt"` with this fix.