### PR TITLE
headers and upload flag #624

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -570,6 +570,7 @@
             if (!self.isPreviewable) {
                 self.showPreview = false;
             }
+            if (!self.showUpload && !self.uploadUrl) self.uploadUrl = 'foo';
             self.uploadFileAttr = !isEmpty($el.attr('name')) ? $el.attr('name') : 'file_data';
             self.reader = null;
             self.formdata = {};

--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -2194,7 +2194,7 @@
             var self = this, config = self.fileActionSettings, footer, out, template = self._getLayoutTemplate(
                 'footer');
             if (self.isUploadable) {
-                footer = template.replace(/\{actions}/g, self._renderFileActions(true, true, false, false, false));
+                footer = template.replace(/\{actions}/g, self._renderFileActions(self.showUpload, true, false, false, false));
                 out = footer.replace(/\{caption}/g, caption)
                     .replace(/\{width}/g, width)
                     .replace(/\{progress}/g, self._renderThumbProgress())

--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -570,7 +570,7 @@
             if (!self.isPreviewable) {
                 self.showPreview = false;
             }
-            if (!self.showUpload && !self.uploadUrl) self.uploadUrl = 'foo';
+            self.uploadUrl = !self.showUpload && !self.uploadUrl ? 'foo' : self.uploadUrl;
             self.uploadFileAttr = !isEmpty($el.attr('name')) ? $el.attr('name') : 'file_data';
             self.reader = null;
             self.formdata = {};

--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -1204,6 +1204,7 @@
                     return self._initXhr(xhrobj, previewId, self.getFileStack().length);
                 },
                 url: self.uploadUrl,
+                headers: self.uploadHeaders,
                 type: 'POST',
                 dataType: 'json',
                 data: self.formdata,
@@ -2671,6 +2672,7 @@
         cancelClass: 'btn btn-default',
         uploadIcon: '<i class="glyphicon glyphicon-upload"></i>',
         uploadClass: 'btn btn-default',
+        uploadHeaders: null,
         uploadUrl: null,
         uploadAsync: true,
         uploadExtraData: {},


### PR DESCRIPTION
[authenticated calls need headers, and showUpload: false should not need uploadUrl; there was a bug where the drag and drop interface wouldn't show without uploadUrl](https://github.com/kartik-v/bootstrap-fileinput/issues/624)