### PR TITLE
Find correct filename in IE9

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -1854,9 +1854,16 @@
             readFile(0);
             self._updateFileDetails(numFiles, false);
         },
+        _findFileName: function (filePath) {
+            var sepIndex = filePath.lastIndexOf('/');
+            if (sepIndex == -1) {
+                sepIndex = filePath.lastIndexOf('\\');
+            }
+            return filePath.split(filePath.substring(sepIndex, sepIndex + 1)).pop();
+        },
         _updateFileDetails: function (numFiles) {
             var self = this, $el = self.$element, fileStack = self.getFileStack(),
-                name = ($el[0].files[0] && $el[0].files[0].name) || (fileStack.length && fileStack[0].name) || '',
+                name = (isIE(9) && self._findFileName($el.val())) || ($el[0].files[0] && $el[0].files[0].name) || (fileStack.length && fileStack[0].name) || '',
                 label = self.slug(name), n = self.isUploadable ? fileStack.length : numFiles,
                 nFiles = previewCache.count(self.id) + n, log = n > 1 ? self._getMsgSelected(nFiles) : label;
             if (self.isError) {


### PR DESCRIPTION
For IE9 only find the correct name for the file to be uploaded as this.$element.files does not exist