### PR TITLE
Wrap readFile(index + 1) in a function to prevent 'unsafe-eval' blocking with CSP

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -1736,7 +1736,7 @@
                     if (self.isUploadable) {
                         self.addToStack(undefined);
                     }
-                    setTimeout(readFile(index + 1), 100);
+                    setTimeout(function(){readFile(index + 1);}, 100);
                     self._initFileActions();
                     if (self.removeFromPreviewOnError) {
                         $('#' + previewId).remove();
@@ -1808,7 +1808,7 @@
                 }
                 if (!self.showPreview) {
                     self.addToStack(file);
-                    setTimeout(readFile(i + 1), 100);
+                    setTimeout(function(){readFile(i + 1);}, 100);
                     self._raise('fileloaded', [file, previewId, i, reader]);
                     return;
                 }


### PR DESCRIPTION
My site have Content Security Policy (CSP) enabled with ```script-src: self 'unsafe-inline' ```
In Chrome I have CSP error after selecting a file.

> Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive

I had to wrap both readFile(...) in the setTimeout() with a function(){} to make it work.

Source : https://developer.chrome.com/extensions/contentSecurityPolicy