### PR TITLE
Add option clearPreviewOnChange

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -2745,7 +2745,7 @@
                     self._resetPreviewThumbs(isAjaxUpload);
                 }
             } else {
-                if (!isAjaxUpload || flagSingle) {
+                if ((!isAjaxUpload && self.clearPreviewOnChange) || flagSingle) {
                     self._resetPreviewThumbs(false);
                     if (flagSingle) {
                         self.clearStack();
@@ -3065,6 +3065,7 @@
         showClose: true,
         showUploadedThumbs: true,
         autoReplace: false,
+        clearPreviewOnChange: true,
         previewClass: '',
         captionClass: '',
         mainClass: '',


### PR DESCRIPTION
When working without ajax upload, the preview is auto clear when people add a new file.
This options allow server upload to keep original image when adding new one.