### PR TITLE
Fix sort index for filesorted event

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -1028,14 +1028,15 @@
             self._validateDefaultPreview();
         },
         _initSortable: function () {
-            var self = this, $preview = self.$preview, $el, settings;
+            var self = this, $el, settings;
             if (!window.Sortable) {
                 return;
             }
-            $el = $preview.find('.file-initial-thumbs');
+            $el = self.$previewContainer.find('.file-initial-thumbs');
             settings = {
                 handle: '.drag-handle-init',
                 dataIdAttr: 'data-preview-id',
+                draggable: '.file-preview-initial',
                 onSort: function (e) {
                     var oldIndex = e.oldIndex, newIndex = e.newIndex;
                     self.initialPreview = moveArray(self.initialPreview, oldIndex, newIndex);


### PR DESCRIPTION
On filesorted event, I always have newIndex & oldIndex set to 0, the stack is also the old one.
If I clearly understand how filesort work, there is an error on selector you have set up for Sortable.
In my case with this fix, the sort works, as the sort index & stack