### PR TITLE
Display file size of empty files correctly

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -2194,6 +2194,8 @@
             }
             if (typeof func === 'function') {
                 out = func(size);
+            } else if (size === 0) {
+                out = '0.00 B';
             } else {
                 i = Math.floor(Math.log(size) / Math.log(1024));
                 sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];


### PR DESCRIPTION
Resolves https://github.com/kartik-v/bootstrap-fileinput/issues/894

0.00 B display is consistent with display of a one byte file (1.00 B) as per the general logic.