### PR TITLE
Cancel after self fields are used.

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -3135,9 +3135,9 @@
                 data = $.extend(true, {}, self._getOutData(), params);
                 data.abortData = self.ajaxAborted.data || {};
                 data.abortMessage = self.ajaxAborted.message;
-                self.cancel();
                 self._setProgress(101, self.$progress, self.msgCancelled);
                 self._showUploadError(self.ajaxAborted.message, data, 'filecustomerror');
+                self.cancel();
                 return true;
             }
             return false;


### PR DESCRIPTION
After calling `cancel()` `self.ajaxAborted` becomes undefined, therefore `self.ajaxAborted.message` throws an error.

## Scope
This pull request includes a

- [ ] Bug fix

## Changes
The following changes were made

- Fix the abort function, so when there is a client validation failure the message gets properly displayed.