### PR TITLE
Do not reset input when upload fails (single-upload mode)

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -2020,8 +2020,10 @@
                             updateUploadLog(i, pid);
                         }
                     } else {
+                        uploadFailed = true;
                         self._showUploadError(data.error, params);
-                        self._setPreviewError($thumb, i);
+                        self._setPreviewError($thumb, i,
+                            multiUploadMode ? null : self.filestack[i]);
                         if (allFiles) {
                             updateUploadLog(i, pid);
                         }


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [x] New feature
- [ ] Translation

## Changes
The following changes were made

- input is not reset when upload fails (single-upload mode)

## Related Issues
[Multiple Ajax Upload does not resend the file after an error][1]
[Input file is reset when upload fails][2]

## Discussion

It's not finished yet. What's left is to fix the preview part. But... do we need that for use case at hand (not just uploading files, but form with a file input)? Your plugin allows to have some fixed (initial) thumbs, that doesn't get overwritten. Thumb list may act as a log (keeps everything you selected or uploaded). And whatnot. But for forms with file inputs even preview might not be necessary. Or if necessary, that would generally be just one image in overwrite mode, so to say. What do you say?

[1]: https://github.com/kartik-v/bootstrap-fileinput/issues/637
[2]: https://github.com/kartik-v/bootstrap-fileinput/issues/983