### PR TITLE
Enhance `refresh` method to overwrite options

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -3725,6 +3725,10 @@
                 config: self.initialPreviewConfig,
                 tags: self.initialPreviewThumbTags
             };
+        },
+        setUploadUrl: function(uploadUrl) {
+            var self = this;
+            self.uploadUrl = uploadUrl;
         }
     };
 


### PR DESCRIPTION
There are use cases where in after initializing the widget, we need to alter the `uploadUrl`. 
For example, if the URL is a function of the selected file type.

This PR essentially adds a setter for this variable. Can be accessed as follows:
```
$('#input').fileinput('setUploadUrl', url);
```
