### PR TITLE
Change Select to Selecionar

### DIFF
--- a/js/locales/pt-BR.js
+++ b/js/locales/pt-BR.js
@@ -24,7 +24,7 @@
         msgNo: 'Não',
         msgNoFilesSelected: 'Nenhum arquivo selecionado',
         msgCancelled: 'Cancelado',
-        msgPlaceholder: 'Select {files}...',
+        msgPlaceholder: 'Selecionar {files}...',
         msgZoomModalHeading: 'Pré-visualização detalhada',
         msgFileRequired: 'Você deve selecionar um arquivo para enviar.',
         msgSizeTooSmall: 'O arquivo "{name}" (<b>{size} KB</b>) é muito pequeno e deve ser maior que <b>{minSize} KB</b>.',


### PR DESCRIPTION
"Select" don't exist in portuguese, the correct translation is "Selecionar"

## Scope
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [x] Translation

## Changes
The following changes were made

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.