### PR TITLE
hot fix for firefox bug on drag and drop

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -1510,6 +1510,7 @@
                     if (!self.isAjaxUpload) {
                         self.changeTriggered = true;
                         $el.get(0).files = files;
+                        $el.trigger('change');
                         setTimeout(function () {
                             self.changeTriggered = false;
                             $el.trigger('change' + self.namespace);


### PR DESCRIPTION
$el.get(0).files = files; causes change event in Chrome. Add $el.trigger('change') for firefox (chrome double event);

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.