### PR TITLE
the last chunk can't trigger event "filechunksuccess"

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -1311,8 +1311,8 @@
                             }
                             rm.processed[id][data[chunkIndex]] = true;
                             rm.processed[id].data = data;
-                            rm.check();
                             self._raise('filechunksuccess', params);
+                            rm.check();
                         }
                     };
                     fnError = function (jqXHR, textStatus, errorThrown) {


### PR DESCRIPTION
This change avoid the last chunk failing to trigger event "filechunksuccess" ,
 becouse  after rm.check(), if all chunks has bean uploaded the next self._raise('filechunksuccess', params); will not run

## Scope
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.