### PR TITLE
Issue "Path Drag and Drop on Chrome, Edge, Safari"

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -84,7 +84,7 @@
         getFileRelativePath: function (file) {
             /** @namespace file.relativePath */
             /** @namespace file.webkitRelativePath */
-            return String(file.relativePath || file.webkitRelativePath || $h.getFileName(file) || null);
+            return String(file.fullPath || file.relativePath || file.webkitRelativePath || $h.getFileName(file) || null);
 
         },
         getFileId: function (file, generateFileId) {
@@ -2244,6 +2244,7 @@
             };
             if (item.isFile) {
                 item.file(function (file) {
+                    file.fullPath = path + file.name;
                     files.push(file);
                 }, errorHandler);
             } else {


### PR DESCRIPTION
## Scope
This pull request includes a

- [X ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- Added a new var for files
- Added a new option for files that have been added throught drag and drop on chrome
-

## Related Issues
https://github.com/kartik-v/bootstrap-fileinput/issues/1545
Path Drag and Drop on Chrome, Edge, Safari #1545