### PR TITLE
Fix #1552: Don't try to exit fullscreen if not in fullscreen mode

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -514,7 +514,7 @@
                         }
                     }
                 }
-            } else {
+            } else if($h.checkFullScreen()) {
                 /** @namespace document.exitFullscreen */
                 /** @namespace document.msExitFullscreen */
                 /** @namespace document.mozCancelFullScreen */


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- Check if modal is in fullscreen mode before trying to exit fullscreen mode

## Related Issues
#1552