### PR TITLE
Enhance and fix resumable and ajax queues

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -5366,7 +5366,7 @@
                 tasksPool = tm.getTasksPool(rm.id);
             if (!self.enableResumableUpload) {
                 return self.$element;
-            } else {
+            } else if(tasksPool) {
                 tasksPool.cancelAllTasks();
             }
             self._raise('fileuploadpaused', [self.fileManager, rm]);
@@ -5400,7 +5400,7 @@
                 rm = self.resumableManager, tm = self.taskManager,
                 tasksPool = tm.getTasksPool(rm.id), len = xhr.length, i;
 
-            if (self.enableResumableUpload) {
+            if (self.enableResumableUpload && tasksPool) {
                 tasksPool.cancelAllTasks().done(function() {
                     self._setProgressCancelled();
                 });

--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -1239,6 +1239,7 @@
                 init: function (id, f, index) {
                     var rm = self.resumableManager, fm = self.fileManager;
                     rm.logs = [];
+                    rm.stack = [];
                     rm.error = '';
                     rm.id = id;
                     rm.file = f.file;


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- changed fileManager.processed to fileManager.filesProcessed
  this makes more sense, for code readability
  this is an optional change

- changed Object.keys to $h.getObjectKeys method
  this is an optional change
  https://stackoverflow.com/questions/5223/length-of-a-javascript-object

- added getObjectKeys method in $h
- added getObjectSize method in $h
- added taskManager in $h
- added $.whenAll jquery extension to handle running all chunks a once if
  resumableUploadOptions.maxThreads is equal to 0
  I think this could be removed, since we could want
  chunks to always be uploaded "maxThreads" at a time.
  If so some code in taskManager.TasksPool.runAllTasksParallels
  could be remove the "// if run all at once" part with the jquery
  extension

- ajax requests are stand alone tasks (promises)
- resumable uploads are a pool of tasks foreach chunks
  they are runned in parrallel

I wont remove the last setInterval for upload: function
this is too much work, and code readability is poor in my opinion.
It would benefit to be reactored using an object approach
instead of a functionnal programming.

There should also be a unique upload method: resumable.
It would be adapted for each options

## Related Issues
#1557