### PR TITLE
Fix #1536: Parse response as string in `_parseError` function

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -2257,7 +2257,7 @@
             /** @namespace jqXHR.responseJSON */
             var self = this, errMsg = $.trim(errorThrown + ''), textPre,
                 text = jqXHR.responseJSON !== undefined && jqXHR.responseJSON.error !== undefined ?
-                    jqXHR.responseJSON.error : jqXHR.responseText;
+                    jqXHR.responseJSON.error.toString() : jqXHR.responseText;
             if (self.cancelling && self.msgUploadAborted) {
                 errMsg = self.msgUploadAborted;
             }


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- parse json answer to String object

## Related Issues
If this is related to an existing ticket, include a link to it as well.
#1536