### PR TITLE
Correct timeout and resumable validation for async uploads

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -3454,20 +3454,18 @@
                 }, self.processDelay);
             };
             fnComplete = function () {
-                setTimeout(function () {
-                    if (self.showPreview) {
-                        $btnUpload.removeAttr('disabled');
-                        $btnDelete.removeAttr('disabled');
-                        $thumb.removeClass('file-uploading');
-                    }
-                    if (!isBatch) {
-                        self.unlock(false);
-                        self._clearFileInput();
-                    } else {
-                        chkComplete();
-                    }
-                    self._initSuccessThumbs();
-                }, self.processDelay);
+                if (self.showPreview) {
+                    $btnUpload.removeAttr('disabled');
+                    $btnDelete.removeAttr('disabled');
+                    $thumb.removeClass('file-uploading');
+                }
+                if (!isBatch) {
+                    self.unlock(false);
+                    self._clearFileInput();
+                } else {
+                    chkComplete();
+                }
+                self._initSuccessThumbs();
             };
             fnError = function (jqXHR, textStatus, errorThrown) {
                 errMsg = self._parseError(op, jqXHR, errorThrown, self.fileManager.getFileName(id));
@@ -5378,7 +5376,7 @@
         cancel: function () {
             var self = this, xhr = self.ajaxRequests,
                 rm = self.resumableManager, tm = self.taskManager,
-                pool = tm.getPool(rm.id), len = xhr.length, i;
+                pool = rm ? tm.getPool(rm.id) : undefined, len = xhr.length, i;
 
             if (self.enableResumableUpload && pool) {
                 pool.cancel().done(function () {


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

 - general progress bar would not stay on cancelled status because of a set timeout on fnComplete
   removing setTimeout on fnComplete because it is not usefull to do so

 - rm is undefined on async upload (not resumable)
   check rm before assigning pool, this is because self.resumableManager is undefined in that case
   so it would throw an unhandled error

## Related Issues
If this is related to an existing ticket, include a link to it as well.

Did no open an issue but this happens  on this conditions

Set async uploads but not resumable :

- uploadAsync: true,
- enableResumableUpload: false, 

Then force the upload to fail (server always return 500 for ex), it will throw ```rm is undefined```
Then chunkComplete would happen when upload is cancelled, and the general progress bar would be set to ```Done```.
Removing the setTimeout fixes this. And dont see any reason setTimout is called.
I tested this against resumable uploads and it still works.