### PR TITLE
Enhance resumable ajax error trapping

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -1633,7 +1633,7 @@
                             return;
                         }
                         outData = self._getOutData(fd, jqXHR);
-                        rm.error = errorThrown;
+                        rm.error = jqXHR.responseJSON && jqXHR.responseJSON.error ? jqXHR.responseJSON.error : errorThrown;
                         rm.logAjaxError(jqXHR, textStatus, errorThrown);
                         self._raise('filechunkajaxerror', [id, index, retry, fm, rm, outData]);
                         rm.pushAjax(index, retry + 1); // push another task


### PR DESCRIPTION
Resumable error message, allow return HTTP code other than 200 with error message

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- Try to fetch 'error' message when http code other than 200 is returned on resumable upload

## Related Issues
If this is related to an existing ticket, include a link to it as well.