### PR TITLE
Fix #1652: Correct error for preupload event when showPreview is false 

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -3533,7 +3533,11 @@
                 if (fm.errors.indexOf(id) !== -1) {
                     delete fm.errors[id];
                 }
-                self._raise('filepreupload', [outData, previewId, i, $thumb.attr('data-fileid')]);
+                if (self.showPreview) {
+                    self._raise('filepreupload', [outData, previewId, i, $thumb.attr('data-fileid')]);
+                } else {
+                    self._raise('filepreupload', [outData, previewId, i]);
+                }
                 $.extend(true, params, outData);
                 if (self._abort(params)) {
                     jqXHR.abort();


### PR DESCRIPTION
https://github.com/kartik-v/bootstrap-fileinput/issues/1652

## Scope
This pull request includes a

- [x ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.