### PR TITLE
Add namespace control on show trigger to avoid interaction with other…

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -2800,6 +2800,7 @@
                 };
             };
             $modal.on(event + '.bs.modal', function (e) {
+                if (e.namespace!=='bs.modal') return;
                 var $btnFull = $modal.find('.btn-fullscreen'), $btnBord = $modal.find('.btn-borderless');
                 if ($modal.data('fileinputPluginId') === self.$element.attr('id')) {
                     self._raise('filezoom' + event, getParams(e));


### PR DESCRIPTION
Hello,

I use some jquery plugin with "show" triggers. The filezoomshow is called too in these cases. 
I added a check on the namespace and the result is fine. 

## Scope
This pull request includes a

- [ ] Bug fix
- [X] New feature
- [ ] Translation

## Changes
The following changes were made

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.