### PR TITLE
Resumable upload error: fix displaying errors 

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -2262,7 +2262,7 @@
         },
         _resetErrors: function (fade) {
             var self = this, $error = self.$errorContainer;
-            if (self.isPersistentError) {
+            if (self.isPersistentError || self.resumableUploadOptions.skipErrorsAndProceed) {
                 return;
             }
             self.isError = false;


### PR DESCRIPTION
When resumableUploadOptions.skipErrorsAndProceed was true and multiple errors could occur during resumable upload, errors were discarded (reset) and only the last error would be displayed. Now all the errors are displayed if resumableUploadOptions.skipErrorsAndProceed is set to true.

## Scope
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- When doing resumable upload and if resumableUploadOptions.skipErrorsAndProceed is set to true, multiple errors are displayed and not only the last one

## Related Issues
kartik-v/bootstrap-fileinput#1687

![bs-fileupload-20210226-01](https://user-images.githubusercontent.com/56750471/109361818-08007600-788a-11eb-80ec-f324bf446bdc.png)
