### PR TITLE
Corrected filesuccessremove event.

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -3616,18 +3616,20 @@
                 }, self.processDelay);
             };
             fnComplete = function () {
-                if (self.showPreview) {
-                    $btnUpload.removeAttr('disabled');
-                    $btnDelete.removeAttr('disabled');
-                    $thumb.removeClass('file-uploading');
-                }
-                if (!isBatch) {
-                    self.unlock(false);
-                    self._clearFileInput();
-                } else {
-                    chkComplete();
-                }
-                self._initSuccessThumbs();
+                setTimeout(function () {
+                    if (self.showPreview) {
+                        $btnUpload.removeAttr('disabled');
+                        $btnDelete.removeAttr('disabled');
+                        $thumb.removeClass('file-uploading');
+                    }
+                    if (!isBatch) {
+                        self.unlock(false);
+                        self._clearFileInput();
+                    } else {
+                        chkComplete();
+                    }
+                    self._initSuccessThumbs();
+                }, self.processDelay);
             };
             fnError = function (jqXHR, textStatus, errorThrown) {
                 errMsg = self._parseError(op, jqXHR, errorThrown, self.fileManager.getFileName(id));


### PR DESCRIPTION
Before the commit fnComplete() calls _initSuccessThumbs() which is called directly without setTimeout and thus when _initSuccessThumbs() runs the successfully uploaded thumb is yet not updated.

So adding setTimeout makes it work correctly.

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made
- Added setTimeout block which was removed earlier in earlier commit [c22ffa9
](https://github.com/kartik-v/bootstrap-fileinput/commit/c22ffa981c851981d82363cc737d5fb12f668a3a)
```
     setTimeout(function () {
          .....
          .....
          .....
     }, self.processDelay);
```

## Related Issues
[1647](https://github.com/kartik-v/bootstrap-fileinput/issues/1647), [1679](https://github.com/kartik-v/bootstrap-fileinput/issues/1679)