### PR TITLE
Enhance reset of file caption title 

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -3480,6 +3480,7 @@
                         if (out === false) {
                             return;
                         }
+                        $cont.find('.file-caption-name').attr('title', '');
                         $thumb.fadeOut('slow', function () {
                             $thumb.remove();
                             if (!self.getFrames().length) {


### PR DESCRIPTION
Clear input title attribute on remove

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- Title Attribute clears on remove if no items left