### PR TITLE
syntax error on danish translations

### DIFF
--- a/js/locales/da.js
+++ b/js/locales/da.js
@@ -8,7 +8,16 @@
  *
  * NOTE: this file must be saved in UTF-8 encoding.
  */
-(function($) {
+(function (factory) {
+    'use strict';
+    if (typeof define === 'function' && define.amd) {
+        define(['jquery'], factory);
+    } else if (typeof module === 'object' && typeof module.exports === 'object') {
+        factory(require('jquery'));
+    } else {
+        factory(window.jQuery);
+    }
+}(function($) {
     "use strict";
 
     $.fn.fileinputLocales['da'] = {


### PR DESCRIPTION
Missing jquery dependancy injection. Webpack fails compiling because of unmatched round brackets

## Scope
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- added jquery dependancy injection and fixed unmatching round brackets