### PR TITLE
Define max files size for input[multiple] - when pick multiple files

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -1147,7 +1147,7 @@
                     if (!id) {
                         return;
                     }
-                    self.fileManager.stack[id] = {
+                        self.fileManager.stack[id] = {
                         file: file,
                         name: $h.getFileName(file),
                         relativePath: $h.getFileRelativePath(file),
@@ -4322,7 +4322,8 @@
             $h.addCss(self.$captionContainer, 'icon-visible');
         },
         _getSize: function (bytes, skipTemplate, sizeUnits) {
-            var self = this, size = parseFloat(bytes), i = 0, factor = self.bytesToKB, func = self.fileSizeGetter, out,
+            console.log(bytes);
+                        var self = this, size = parseFloat(bytes), i = 0, factor = self.bytesToKB, func = self.fileSizeGetter, out,
                 sizeHuman = size, newSize;
             if (!$.isNumeric(bytes) || !$.isNumeric(size)) {
                 return '';
@@ -4501,7 +4502,7 @@
             self._initSortable();
         },
         _setThumbAttr: function (id, caption, size, description) {
-            var self = this, $frame = self._getFrame(id);
+                        var self = this, $frame = self._getFrame(id);
             if ($frame.length) {
                 size = size && size > 0 ? self._getSize(size) : '';
                 $frame.data({'caption': caption, 'size': size, 'description': description || ''});
@@ -5722,7 +5723,7 @@
                     //fileSize é KB
                     let CaptionGroup = [];
                     let fileSizeGroup = 0;
-                    //sizeHuman = 0; TODO: tratar melhor o sizeHuman
+                    //sizeHuman = 0; TODO: tratar melhor o sizeHuman da minha forma e depois recolocar a variavel no print
                     Object.values(files).forEach(file => {
                         fileSizeGroup = fileSizeGroup + (file.size / self.bytesToKB);
                         CaptionGroup.push(file.name);
@@ -5731,7 +5732,7 @@
                     if(fileSizeGroup > self.maxMultipleFileSize){
                         msg = self.msgMultipleSizeTooLarge.setTokens({
                             'name': CaptionGroup,
-                            'size': sizeHuman,
+                            //'size': null,
                             'maxSize': self._getSize(self.maxMultipleFileSize * self.bytesToKB, true)
                         });
     
@@ -5741,7 +5742,7 @@
                     }
 
                 } else if (self.maxFileSize > 0 && fileSize > self.maxFileSize) {
-                    msg = self.msgSizeTooLarge.setTokens({
+                        msg = self.msgSizeTooLarge.setTokens({
                         'name': caption,
                         'size': sizeHuman,
                         'maxSize': self._getSize(self.maxFileSize * self.bytesToKB, true)
@@ -6527,7 +6528,7 @@
         msgFileRequired: 'You must select a file to upload.',
         msgSizeTooSmall: 'File "{name}" (<b>{size}</b>) is too small and must be larger than <b>{minSize}</b>.',
         msgSizeTooLarge: 'File "{name}" (<b>{size}</b>) exceeds maximum allowed upload size of <b>{maxSize}</b>.',
-        msgMultipleSizeTooLarge: 'Files"{name}" (<b>{size}</b>) exceeds maximum allowed upload size of <b>{maxSize}</b>.',
+        msgMultipleSizeTooLarge: 'Files"{name}" exceeds maximum allowed upload size of <b>{maxSize}</b>.',
         msgFilesTooLess: 'You must select at least <b>{n}</b> {files} to upload.',
         msgFilesTooMany: 'Number of files selected for upload <b>({n})</b> exceeds maximum allowed limit of <b>{m}</b>.',
         msgTotalFilesTooMany: 'You can upload a maximum of <b>{m}</b> files (<b>{n}</b> files detected).',

--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -2470,6 +2470,7 @@
             return 'other';
         },
         _getPreviewIcon: function (fname) {
+            console.log(fname);
             var self = this, ext, out = null;
             if (fname && fname.indexOf('.') > -1) {
                 ext = fname.split('.').pop();
@@ -4322,7 +4323,6 @@
             $h.addCss(self.$captionContainer, 'icon-visible');
         },
         _getSize: function (bytes, skipTemplate, sizeUnits) {
-            console.log(bytes);
                         var self = this, size = parseFloat(bytes), i = 0, factor = self.bytesToKB, func = self.fileSizeGetter, out,
                 sizeHuman = size, newSize;
             if (!$.isNumeric(bytes) || !$.isNumeric(size)) {
@@ -5572,10 +5572,14 @@
                 readFile, fileTypes = self.allowedFileTypes, typLen = fileTypes ? fileTypes.length : 0,
                 fileExt = self.allowedFileExtensions, strExt = $h.isEmpty(fileExt) ? '' : fileExt.join(', '),
                 throwError = function (msg, file, previewId, index, fileId) {
+
+                    console.log(files);
                                         var $thumb, p1 = $.extend(true, {}, self._getOutData(null, {}, {}, files),
                             {id: previewId, index: index, fileId: fileId}),
                         p2 = {id: previewId, index: index, fileId: fileId, file: file, files: files};
-                    self._previewDefault(file, true);
+                        Object.values(files).forEach(x => {
+                            self._previewDefault(x, true);    
+                        });
                     $thumb = self._getFrame(previewId, true);
                     self._toggleLoading('hide');
                     if (self.isAjaxUpload) {
@@ -5716,14 +5720,10 @@
                     }
                     return;
                 }
-                /* fileSize: tamanho do ficheiro carregado
-                    self.maxFileSize: tamanho dos ficheiros definido pelo user
-                 */
+                
                 if(self.maxMultipleFileSize > 0 && files.length > 1){
-                    //fileSize é KB
                     let CaptionGroup = [];
                     let fileSizeGroup = 0;
-                    //sizeHuman = 0; TODO: tratar melhor o sizeHuman da minha forma e depois recolocar a variavel no print
                     Object.values(files).forEach(file => {
                         fileSizeGroup = fileSizeGroup + (file.size / self.bytesToKB);
                         CaptionGroup.push(file.name);
@@ -5732,10 +5732,8 @@
                     if(fileSizeGroup > self.maxMultipleFileSize){
                         msg = self.msgMultipleSizeTooLarge.setTokens({
                             'name': CaptionGroup,
-                            //'size': null,
                             'maxSize': self._getSize(self.maxMultipleFileSize * self.bytesToKB, true)
                         });
-    
                         
                         throwError(msg, file, previewId, i, fileId);
                         return;

--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -2470,8 +2470,7 @@
             return 'other';
         },
         _getPreviewIcon: function (fname) {
-            console.log(fname);
-            var self = this, ext, out = null;
+                        var self = this, ext, out = null;
             if (fname && fname.indexOf('.') > -1) {
                 ext = fname.split('.').pop();
                 if (self.previewFileIconSettings) {
@@ -5572,8 +5571,6 @@
                 readFile, fileTypes = self.allowedFileTypes, typLen = fileTypes ? fileTypes.length : 0,
                 fileExt = self.allowedFileExtensions, strExt = $h.isEmpty(fileExt) ? '' : fileExt.join(', '),
                 throwError = function (msg, file, previewId, index, fileId) {
-
-                    console.log(files);
                                         var $thumb, p1 = $.extend(true, {}, self._getOutData(null, {}, {}, files),
                             {id: previewId, index: index, fileId: fileId}),
                         p2 = {id: previewId, index: index, fileId: fileId, file: file, files: files};
@@ -5720,7 +5717,7 @@
                     }
                     return;
                 }
-                
+
                 if(self.maxMultipleFileSize > 0 && files.length > 1){
                     let CaptionGroup = [];
                     let fileSizeGroup = 0;


### PR DESCRIPTION
## Scope
I made this to allow developers to set also max file size when we pick multiiple files, to set up, you must provide new parameter called: "maxMultipleFileSize"
This pull request includes a

- [x] Bug fix
- [x] New feature

## Changes
The following changes were made

- new parameter "maxMultipleFileSize" was added to allow developers to set max files size for multiple files 
- is possíble to see preview error for multiple files, when their full size exceeds what was configured

## Related Issues
If this is related to an existing ticket, include a link to it as well.
- https://github.com/kartik-v/bootstrap-fileinput/issues/1849
## Ilustrations
![image](https://github.com/kartik-v/bootstrap-fileinput/assets/100171179/ee619046-4153-4ce7-80ef-71951d2f2ee1)
