### PR TITLE
Clarify that upload speed metrics are in bits

### DIFF
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -7442,7 +7442,7 @@
   // noinspection HtmlUnknownAttribute
   $.fn.fileinputLocales.en = {
     sizeUnits: ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"],
-    bitRateUnits: ["B/s", "KB/s", "MB/s", "GB/s", "TB/s", "PB/s", "EB/s", "ZB/s", "YB/s"],
+    bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
     fileSingle: "file",
     filePlural: "files",
     browseLabel: "Browse &hellip;",

--- a/js/locales/LANG.js
+++ b/js/locales/LANG.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['_LANG_'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'file',
         filePlural: 'files',
         browseLabel: 'Browse &hellip;',

--- a/js/locales/ar.js
+++ b/js/locales/ar.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['ar'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'ملف',
         filePlural: 'ملفات',
         browseLabel: 'تصفح &hellip;',

--- a/js/locales/az.js
+++ b/js/locales/az.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['az'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'fayl',
         filePlural: 'fayl',
         browseLabel: 'Seç &hellip;',

--- a/js/locales/bg.js
+++ b/js/locales/bg.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['bg'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'файл',
         filePlural: 'файла',
         browseLabel: 'Избери &hellip;',

--- a/js/locales/ca.js
+++ b/js/locales/ca.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['ca'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'arxiu',
         filePlural: 'arxius',
         browseLabel: 'Examinar &hellip;',

--- a/js/locales/cr.js
+++ b/js/locales/cr.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['cr'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'datoteka',
         filePlural: 'datoteke',
         browseLabel: 'Izaberi &hellip;',

--- a/js/locales/cs.js
+++ b/js/locales/cs.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['cs'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'soubor',
         filePlural: 'soubory',
         browseLabel: 'Vybrat &hellip;',

--- a/js/locales/da.js
+++ b/js/locales/da.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['da'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'fil',
         filePlural: 'filer',
         browseLabel: 'Browse &hellip;',

--- a/js/locales/de.js
+++ b/js/locales/de.js
@@ -20,7 +20,7 @@
 
     $.fn.fileinputLocales['de'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'Datei',
         filePlural: 'Dateien',
         browseLabel: 'Auswählen&hellip;',

--- a/js/locales/el.js
+++ b/js/locales/el.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['el'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'αρχείο',
         filePlural: 'αρχεία',
         browseLabel: 'Αναζήτηση &hellip;',

--- a/js/locales/es.js
+++ b/js/locales/es.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['es'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'archivo',
         filePlural: 'archivos',
         browseLabel: 'Examinar &hellip;',

--- a/js/locales/et.js
+++ b/js/locales/et.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['et'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'fail',
         filePlural: 'failid',
         browseLabel: 'Sirvi &hellip;',

--- a/js/locales/eu.js
+++ b/js/locales/eu.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['eu'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'fitxategia',
         filePlural: 'fitxategiak',
         browseLabel: 'Aztertu &hellip;',

--- a/js/locales/fa.js
+++ b/js/locales/fa.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['fa'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'فایل',
         filePlural: 'فایل‌ها',
         browseLabel: 'مرور &hellip;',

--- a/js/locales/fr.js
+++ b/js/locales/fr.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['fr'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'fichier',
         filePlural: 'fichiers',
         browseLabel: 'Parcourir &hellip;',

--- a/js/locales/gl.js
+++ b/js/locales/gl.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['gl'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'arquivo',
         filePlural: 'arquivos',
         browseLabel: 'Examinar &hellip;',

--- a/js/locales/he.js
+++ b/js/locales/he.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['he'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'קובץ',
         filePlural: 'קבצים',
         browseLabel: 'העלאה &hellip;',

--- a/js/locales/hu.js
+++ b/js/locales/hu.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['hu'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'fájl',
         filePlural: 'fájlok',
         browseLabel: 'Tallózás...',

--- a/js/locales/id.js
+++ b/js/locales/id.js
@@ -24,7 +24,7 @@
 
     $.fn.fileinputLocales['id'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'berkas',
         filePlural: 'berkas',
         browseLabel: 'Pilih berkas &hellip;',

--- a/js/locales/it.js
+++ b/js/locales/it.js
@@ -24,7 +24,7 @@
 
     $.fn.fileinputLocales['it'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'file',
         filePlural: 'file',
         browseLabel: 'Sfoglia &hellip;',

--- a/js/locales/ja.js
+++ b/js/locales/ja.js
@@ -29,7 +29,7 @@
 
     $.fn.fileinputLocales['ja'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'ファイル',
         filePlural: 'ファイル',
         browseLabel: 'ファイルを選択 &hellip;',

--- a/js/locales/ka.js
+++ b/js/locales/ka.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['ka'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'ფაილი',
         filePlural: 'ფაილები',
         browseLabel: 'არჩევა &hellip;',

--- a/js/locales/kr.js
+++ b/js/locales/kr.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['kr'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: '파일',
         filePlural: '파일들',
         browseLabel: '찾아보기 &hellip;',

--- a/js/locales/kz.js
+++ b/js/locales/kz.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['kz'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'файл',
         filePlural: 'файлдар',
         browseLabel: 'Таңдау &hellip;',

--- a/js/locales/lt.js
+++ b/js/locales/lt.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['lt'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'failas',
         filePlural: 'failai',
         browseLabel: 'Naršyti &hellip;',

--- a/js/locales/lv.js
+++ b/js/locales/lv.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['lv'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'failu',
         filePlural: 'faili',
         browseLabel: 'Izvēlaties &hellip;',

--- a/js/locales/ms.js
+++ b/js/locales/ms.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['ms'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'fail',
         filePlural: 'fail-fail',
         browseLabel: 'Semak imbas &hellip;',

--- a/js/locales/nl.js
+++ b/js/locales/nl.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['nl'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'bestand',
         filePlural: 'bestanden',
         browseLabel: 'Zoek &hellip;',

--- a/js/locales/no.js
+++ b/js/locales/no.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['no'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'fil',
         filePlural: 'filer',
         browseLabel: 'Bla gjennom &hellip;',

--- a/js/locales/pl.js
+++ b/js/locales/pl.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['pl'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'plik',
         filePlural: 'pliki',
         browseLabel: 'Przeglądaj &hellip;',

--- a/js/locales/pt-BR.js
+++ b/js/locales/pt-BR.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['pt-BR'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'arquivo',
         filePlural: 'arquivos',
         browseLabel: 'Procurar &hellip;',

--- a/js/locales/pt.js
+++ b/js/locales/pt.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['pt'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'ficheiro',
         filePlural: 'ficheiros',
         browseLabel: 'Procurar &hellip;',

--- a/js/locales/ro.js
+++ b/js/locales/ro.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['ro'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'fișier',
         filePlural: 'fișiere',
         browseLabel: 'Răsfoiește &hellip;',

--- a/js/locales/ru.js
+++ b/js/locales/ru.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['ru'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'файл',
         filePlural: 'файлы',
         browseLabel: 'Выбрать &hellip;',

--- a/js/locales/sk.js
+++ b/js/locales/sk.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['sk'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'súbor',
         filePlural: 'súbory',
         browseLabel: 'Vybrať &hellip;',

--- a/js/locales/sl.js
+++ b/js/locales/sl.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['sl'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'datoteka',
         filePlural: 'datotek',
         browseLabel: 'Prebrskaj &hellip;',

--- a/js/locales/sr-latn.js
+++ b/js/locales/sr-latn.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['sr-latn'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'dokument',
         filePlural: 'dokumenti',
         browseLabel: 'Odaberi dokument &hellip;',

--- a/js/locales/sv.js
+++ b/js/locales/sv.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['sv'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'fil',
         filePlural: 'filer',
         browseLabel: 'Bläddra &hellip;',

--- a/js/locales/th.js
+++ b/js/locales/th.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['th'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'ไฟล์',
         filePlural: 'ไฟล์',
         browseLabel: 'เลือกดู &hellip;',

--- a/js/locales/tr.js
+++ b/js/locales/tr.js
@@ -22,7 +22,7 @@
 
     $.fn.fileinputLocales['tr'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'dosya',
         filePlural: 'dosyalar',
         browseLabel: 'Gözat &hellip;',

--- a/js/locales/uk.js
+++ b/js/locales/uk.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['uk'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'файл',
         filePlural: 'файли',
         browseLabel: 'Обрати &hellip;',

--- a/js/locales/ur.js
+++ b/js/locales/ur.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['ur'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'فائل',
         filePlural: 'فائلیں',
         browseLabel: 'براؤز کریں &hellip;',

--- a/js/locales/uz-Cy.js
+++ b/js/locales/uz-Cy.js
@@ -21,7 +21,7 @@
 
     $.fn.fileinputLocales['uz-cyrl'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'файл',
         filePlural: 'файллар',
         browseLabel: 'Танлаш &hellip;',

--- a/js/locales/uz.js
+++ b/js/locales/uz.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales.uz = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'fayl',
         filePlural: 'fayllar',
         browseLabel: 'Tanlash &hellip;',

--- a/js/locales/vi.js
+++ b/js/locales/vi.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['vi'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: 'tập tin',
         filePlural: 'các tập tin',
         browseLabel: 'Duyệt &hellip;',

--- a/js/locales/zh-TW.js
+++ b/js/locales/zh-TW.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['zh-TW'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: '單一檔案',
         filePlural: '複選檔案',
         browseLabel: '瀏覽 &hellip;',

--- a/js/locales/zh.js
+++ b/js/locales/zh.js
@@ -23,7 +23,7 @@
 
     $.fn.fileinputLocales['zh'] = {
         sizeUnits: ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 
-        bitRateUnits: ['B/s', 'KB/s', 'MB/s', 'GB/s', 'TB/s', 'PB/s', 'EB/s', 'ZB/s', 'YB/s'],
+        bitRateUnits: ["bps", "Kbps", "Mbps", "Gbps", "Tbps", "Pbps", "Ebps", "Zbps", "Ybps"],
         fileSingle: '文件',
         filePlural: '个文件',
         browseLabel: '选择 &hellip;',


### PR DESCRIPTION
## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made

- Changed MB/s and such to Mbps to clarify that it's actually bits, not bytes

Alternate patch, keep the strings the same and change the displayed value to bytes:

```diff
diff --git a/js/fileinput.js b/js/fileinput.js
index 59a0e6b..db5046b 100755
--- a/js/fileinput.js
+++ b/js/fileinput.js
@@ -1192,7 +1192,7 @@
               n = parseFloat(fm.bpsLog[i]);
               j++;
             }
-            fm.bps = (j > 0 ? n / j : 0) * 64;
+            fm.bps = (j > 0 ? n / j : 0) * 8;
           }, delay);
           out = {
             fileId: id,
```