### PR TITLE
Fix invalid URLs in examples by replacing lorempixel.com with dummyimage.com

### DIFF
--- a/examples/index-bs3.html
+++ b/examples/index-bs3.html
@@ -200,9 +200,9 @@
         overwriteInitial: false,
         initialPreviewAsData: true,
         initialPreview: [
-            "http://lorempixel.com/1920/1080/transport/1",
-            "http://lorempixel.com/1920/1080/transport/2",
-            "http://lorempixel.com/1920/1080/transport/3"
+            "https://dummyimage.com/640x360/a0f.png&text=Transport+1",
+            "https://dummyimage.com/640x360/a0f.png&text=Transport+2",
+            "https://dummyimage.com/640x360/a0f.png&text=Transport+3"
         ],
         initialPreviewConfig: [
             {caption: "transport-1.jpg", size: 329892, width: "120px", url: "{$url}", key: 1},
@@ -246,9 +246,9 @@
             overwriteInitial: false,
             initialPreviewAsData: true,
             initialPreview: [
-                "http://lorempixel.com/1920/1080/nature/1",
-                "http://lorempixel.com/1920/1080/nature/2",
-                "http://lorempixel.com/1920/1080/nature/3"
+                "https://dummyimage.com/1920x1080/1aa.png&text=Nature+1",
+                "https://dummyimage.com/1920x1080/2ef.png&text=Nature+2",
+                "https://dummyimage.com/1920x1080/3f0.png&text=Nature+3"
             ],
             initialPreviewConfig: [
                 {caption: "nature-1.jpg", size: 329892, width: "120px", url: "{$url}", key: 1},

--- a/examples/index-bs4.html
+++ b/examples/index-bs4.html
@@ -197,9 +197,9 @@
         overwriteInitial: false,
         initialPreviewAsData: true,
         initialPreview: [
-            "http://lorempixel.com/1920/1080/transport/1",
-            "http://lorempixel.com/1920/1080/transport/2",
-            "http://lorempixel.com/1920/1080/transport/3"
+            "https://dummyimage.com/640x360/a0f.png&text=Transport+1",
+            "https://dummyimage.com/640x360/a0f.png&text=Transport+2",
+            "https://dummyimage.com/640x360/a0f.png&text=Transport+3"
         ],
         initialPreviewConfig: [
             {caption: "transport-1.jpg", size: 329892, width: "120px", url: "{$url}", key: 1},
@@ -243,9 +243,9 @@
             overwriteInitial: false,
             initialPreviewAsData: true,
             initialPreview: [
-                "http://lorempixel.com/1920/1080/nature/1",
-                "http://lorempixel.com/1920/1080/nature/2",
-                "http://lorempixel.com/1920/1080/nature/3"
+                "https://dummyimage.com/1920x1080/1aa.png&text=Nature+1",
+                "https://dummyimage.com/1920x1080/2ef.png&text=Nature+2",
+                "https://dummyimage.com/1920x1080/3f0.png&text=Nature+3"
             ],
             initialPreviewConfig: [
                 {caption: "nature-1.jpg", size: 329892, width: "120px", url: "{$url}", key: 1},


### PR DESCRIPTION
## Description
The `lorempixel.com` service used in the example files (`examples/index-bs3.html` and `examples/index-bs4.html`) is no longer functional, resulting in broken image previews. This PR replaces the invalid URLs with working alternatives from `dummyimage.com` to ensure the examples display correctly.

## Changes Made
- Updated `initialPreview` arrays in JavaScript code within `examples/index-bs3.html` and `examples/index-bs4.html`.
- Replaced `http://lorempixel.com/1920/1080/transport/[1-3]` with `https://dummyimage.com/640x360/a0f.png&text=Transport+[1-3]`.
- Replaced `http://lorempixel.com/1920/1080/nature/[1-3]` with `https://dummyimage.com/1920x1080/[color].png&text=Nature+[1-3]` (with appropriate colors).

## Testing
- Verified that the new URLs load images correctly in a browser.
- No changes to core functionality; only example assets updated.

## Related Issues
- Fixes broken image previews in Bootstrap 3 and 4 example pages.

Closes # [if applicable, link to an issue number from the original repo]